### PR TITLE
Remove repositories from POM.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,11 +150,6 @@
     </dependency>
   </dependencies>
   <repositories>
-    <repository>
-      <id>socrata</id>
-      <name>socrata</name>
-      <url>https://repo.socrata.com/artifactory/libs-release</url>
-    </repository>
   </repositories>
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>


### PR DESCRIPTION
With the repositories listed here the compiler fails. It fails for a confusing and obscure reason. It fails with a 401 against files which do not exist.

Removing this allows the project to compile (even though this is basically duplicated in ~/.m2/settings.xml)