### PR TITLE
Jackson custom scala config

### DIFF
--- a/common-redshift/src/main/scala/com/socrata/config/CommonObjectMapperCustomizer.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/CommonObjectMapperCustomizer.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.datatype.jsr310.{JSR310Module, JavaTimeModule}
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import io.quarkus.jackson.ObjectMapperCustomizer
 import jakarta.inject.Singleton
@@ -13,6 +13,7 @@ object CommonObjectMapperCustomizer {
 
   def customize(objectMapper: ObjectMapper): Unit = {
     objectMapper
+      .registerModule(new JavaTimeModule())
       .registerModule(DefaultScalaModule)
       .configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, true)
       .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)

--- a/common-redshift/src/main/scala/com/socrata/config/CommonObjectMapperCustomizer.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/CommonObjectMapperCustomizer.scala
@@ -3,11 +3,13 @@ package com.socrata.config
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.annotation.PropertyAccessor
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import io.quarkus.jackson.ObjectMapperCustomizer
 import jakarta.inject.Singleton
 
-object JacksonConfig {
+object CommonObjectMapperCustomizer {
 
   def customize(objectMapper: ObjectMapper): Unit = {
     objectMapper
@@ -16,11 +18,25 @@ object JacksonConfig {
       .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
       .setVisibility(PropertyAccessor.FIELD, Visibility.ANY) :: ClassTagExtensions
   }
+
+  lazy val Default = {
+    val objectMapper = new ObjectMapper()
+    objectMapper.findAndRegisterModules()
+    customize(objectMapper)
+    objectMapper
+  }
+
+  lazy val Yaml = {
+    val objectMapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
+    objectMapper.findAndRegisterModules()
+    customize(objectMapper)
+    objectMapper
+  }
 }
 
 //This class is used to configure the applications ObjectMapper, the jackson serde, to be friendlier with scala.
-class JacksonConfig extends ObjectMapperCustomizer {
+class CommonObjectMapperCustomizer extends ObjectMapperCustomizer {
   override def customize(objectMapper: ObjectMapper): Unit = {
-    JacksonConfig.customize(objectMapper)
+    CommonObjectMapperCustomizer.customize(objectMapper)
   }
 }

--- a/common-redshift/src/main/scala/com/socrata/config/CommonObjectMapperCustomizer.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/CommonObjectMapperCustomizer.scala
@@ -2,19 +2,26 @@ package com.socrata.config
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility
 import com.fasterxml.jackson.annotation.PropertyAccessor
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
 import com.fasterxml.jackson.datatype.jsr310.{JSR310Module, JavaTimeModule}
 import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
+import com.socrata.converter.FiniteDurationDeserializer
 import io.quarkus.jackson.ObjectMapperCustomizer
 import jakarta.inject.Singleton
+
+import scala.concurrent.duration.FiniteDuration
 
 object CommonObjectMapperCustomizer {
 
   def customize(objectMapper: ObjectMapper): Unit = {
+    val simpleModule = new SimpleModule()
+    simpleModule.addDeserializer(classOf[FiniteDuration], new FiniteDurationDeserializer)
     objectMapper
       .registerModule(new JavaTimeModule())
       .registerModule(DefaultScalaModule)
+      .registerModule(simpleModule)
       .configure(DeserializationFeature.FAIL_ON_NULL_CREATOR_PROPERTIES, true)
       .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
       .setVisibility(PropertyAccessor.FIELD, Visibility.ANY) :: ClassTagExtensions

--- a/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
@@ -1,0 +1,121 @@
+package com.socrata.config
+
+import com.fasterxml.jackson.databind.node.{ObjectNode, TextNode}
+import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.socrata.config.JacksonProxyConfigBuilder.merge
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+
+object JacksonProxyConfigBuilder{
+
+  //Merges ConfigSources into a JsonNode (folding), taking the starting node
+   def merge(configSources: Seq[ConfigSource], start: JsonNode): JsonNode = {
+    configSources.foldLeft(
+      start
+    )(
+      (acc, item) => merge(acc, item.read())
+    )
+  }
+
+  //Merges two JsonNodes
+   def merge(mainNode: JsonNode, updateNode: JsonNode): JsonNode = {
+    val fieldNames = updateNode.fieldNames
+    while (fieldNames.hasNext) {
+      val fieldName = fieldNames.next
+      val jsonNode = mainNode.get(fieldName)
+      if (jsonNode != null && jsonNode.isObject) merge(jsonNode, updateNode.get(fieldName))
+      else mainNode match {
+        case node: ObjectNode =>
+          val value = updateNode.get(fieldName)
+          node.replace(fieldName, value)
+        case _ =>
+      }
+    }
+    mainNode
+  }
+}
+
+trait ConfigSource {
+  def read(): JsonNode
+}
+
+trait ConfigProvider{
+  //Get a prefixed config interface/trait.
+  def proxy[T](path: String, clazz: Class[T]): T
+  //Use the root to get the config interface/trait.
+  def proxy[T](clazz: Class[T]): T
+  //Once you chunk, you lose access to ConfigBuilder and cannot source further.
+  def chunk(path:String): ConfigProvider
+}
+
+trait ConfigBuilder{
+  //Allows you to either continue adding sources, or complete the proxying via the provider
+  def withSources(configSources: ConfigSource*): ConfigBuilder with ConfigProvider
+}
+
+case class JacksonProxyConfigBuilder(private val objectMapper:ObjectMapper) extends ConfigBuilder {
+  def withSources(configSources: ConfigSource*): JacksonProxyConfigProvider =
+    JacksonProxyConfigProvider(
+      //Merges config sources into a JsonNode, starting from a blank empty JsonNode
+      merge(configSources,objectMapper.createObjectNode().asInstanceOf[JsonNode]),
+      objectMapper
+    )
+}
+
+//Uses Jacksons to delegate method calls of a proxy, backed by a JsonNode. Uses an ObjectMapper to convert/marshall stuff.
+case class JsonNodeBackedJacksonInvocationHandler(data: JsonNode, objectMapper:ObjectMapper) extends InvocationHandler {
+  def invoke(proxy: scala.AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
+    method.getName match{
+      //Simple implementation for toString, when the root interface is accessed directly.
+      case "toString" => data.toString //Could also make it pretty?
+      //implement others when it becomes important...ie equals/hash...not sure this matters much for our configs yet?
+      case methodName => data.findValue(methodName) match {
+        case null => throw new NotImplementedError(s"Unsupported method name '$methodName', implement it above (probably)!")
+        //Its an object, so instead of using reflection - lets also construct a proxy for this child. This lets us use nested interfaces, neat.
+        case value: ObjectNode => JacksonProxyConfigProvider(value, objectMapper).proxy(method.getReturnType).asInstanceOf[AnyRef]
+        //Convert the JsonNode object to something typed, like a TextNode to a String...etc
+        case value => objectMapper.convertValue(
+          value,
+          method.getReturnType
+        ).asInstanceOf[AnyRef]
+      }
+    }
+  }
+}
+
+case class JacksonProxyConfigProvider(private val data: JsonNode, private val objectMapper:ObjectMapper) extends ConfigProvider with ConfigBuilder {
+
+  def withSources(configSources: ConfigSource*): JacksonProxyConfigProvider =
+    JacksonProxyConfigProvider(
+      //Merge new sources with existing JsonNode
+      merge(configSources,data),
+      objectMapper
+    )
+
+  def chunk(path:String): JacksonProxyConfigProvider = JacksonProxyConfigProvider(data.findValue(path),objectMapper)
+
+  private def proxy[T](clazz: Class[T], newData: JsonNode): T = {
+    //We will return a proxy that will delegate method calls that are backed by a JsonNode and Jackson
+    Proxy.newProxyInstance(
+      //Use the classLoader of the target class?
+      clazz.getClassLoader,
+      //This anonymous proxy will only be implementing a single interface/trait (which is our target marshalling class)
+      Array(clazz),
+      //Uses Jackson to delegate method calls backed by a JsonNode
+      JsonNodeBackedJacksonInvocationHandler(
+        newData,
+        objectMapper)
+      //Our proxy will implement our target interface/trait (clazz), so we will force cast it to look like this type
+    ).asInstanceOf[T]
+  }
+
+  def proxy[T](path: String, clazz: Class[T]): T = {
+    //First extract the value at the json path from the root node, then use this as the proxy data
+    proxy(clazz, data.findValue(path))
+  }
+
+  def proxy[T](clazz: Class[T]): T = {
+    //Use the root data as the proxy data
+    proxy(clazz, data)
+  }
+}

--- a/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
@@ -1,6 +1,6 @@
 package com.socrata.config
 
-import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode, TextNode}
+import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.socrata.config.JacksonProxyConfigBuilder.merge
 
@@ -126,11 +126,11 @@ case class JsonNodeBackedJacksonInvocationHandler(data: JsonNode, objectMapper:O
     out.asInstanceOf[AnyRef]
   }
 
-  private def handleObject[T](data: JsonNode, method: Method): Any = {
+  private def handleObject(data: JsonNode, method: Method): Any = {
     method.getReturnType.getName match {
       //TODO Option of simple vs Option of complex, later check if target class is interface or not, rather than try.
       case "scala.Option" => Try(doProxy(data, innerGenericClass(method))) match {
-        case Failure(exception) => Try(doConvert(
+        case Failure(_) => Try(doConvert(
           data.toString,
           innerGenericClass(method)
         )) match {

--- a/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
@@ -79,8 +79,8 @@ case class JsonNodeBackedJacksonInvocationHandler(data: JsonNode, objectMapper:O
         case value: ObjectNode => method.getReturnType.getName match {
           //TODO Option of simple vs Option of complex, later check if target class is interface or not, rather than try.
           case "scala.Option" => Try(JacksonProxyConfigProvider(value, objectMapper).proxy(Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)).asInstanceOf[AnyRef]) match {
-            case Failure(exception) => Try(objectMapper.convertValue(
-              value,
+            case Failure(exception) => Try(objectMapper.readValue(
+              value.toString,
               Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)
             ).asInstanceOf[AnyRef]) match {
               case Failure(exception) => None
@@ -93,20 +93,20 @@ case class JsonNodeBackedJacksonInvocationHandler(data: JsonNode, objectMapper:O
         case value: ArrayNode => value.elements().asScala.toList.map {
           //TODO Array item of simple vs Array item of complex, same here, later check if target class is interface or not, rather than try
           case item: ObjectNode => Try(JacksonProxyConfigProvider(item, objectMapper).proxy(Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)).asInstanceOf[AnyRef]) match {
-            case Failure(_) => objectMapper.convertValue(
-              item,
+            case Failure(_) => objectMapper.readValue(
+              item.toString,
               Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)
             ).asInstanceOf[AnyRef]
             case Success(value) =>  value
           }
-          case item => objectMapper.convertValue(
-            item,
+          case item => objectMapper.readValue(
+            item.toString,
             Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)
           ).asInstanceOf[AnyRef]
         }
         //Convert the JsonNode object to something typed, like a TextNode to a String...etc
-        case value => objectMapper.convertValue(
-          value,
+        case value => objectMapper.readValue(
+          value.toString,
           method.getReturnType
         ).asInstanceOf[AnyRef]
       }

--- a/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/JacksonProxyConfig.scala
@@ -6,6 +6,7 @@ import com.socrata.config.JacksonProxyConfigBuilder.merge
 
 import java.lang.reflect.{InvocationHandler, Method, ParameterizedType, Proxy}
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.socrata.config.JsonNodeBackedJacksonInvocationHandler.{innerGenericClass, kebab}
 
 import scala.util.{Failure, Success, Try}
 import scala.collection.JavaConverters._
@@ -40,6 +41,7 @@ object JacksonProxyConfigBuilder{
 }
 
 trait ConfigSource {
+  //Anything that can produce json
   def read(): JsonNode
 }
 
@@ -48,7 +50,7 @@ trait ConfigProvider{
   def proxy[T](path: String, clazz: Class[T]): T
   //Use the root to get the config interface/trait.
   def proxy[T](clazz: Class[T]): T
-  //Once you chunk, you lose access to ConfigBuilder and cannot source further.
+  //Selects a subset of configs based on prefix, Once you chunk, you lose access to ConfigBuilder and cannot source further.
   def chunk(path:String): ConfigProvider
 }
 
@@ -66,52 +68,83 @@ case class JacksonProxyConfigBuilder(private val objectMapper:ObjectMapper) exte
     )
 }
 
-//Uses Jacksons to delegate method calls of a proxy, backed by a JsonNode. Uses an ObjectMapper to convert/marshall stuff.
+object JsonNodeBackedJacksonInvocationHandler{
+  def innerGenericClass(method: Method): Class[_] = {
+    Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)
+  }
+
+  //We will strictly use kebab case
+  def kebab(in: String): String = {
+    PropertyNamingStrategies.KebabCaseStrategy.INSTANCE.translate(in)
+  }
+}
+
+//Uses Jackson to delegate method calls of a proxy, backed by a JsonNode. Uses an ObjectMapper to convert/marshall stuff.
 case class JsonNodeBackedJacksonInvocationHandler(data: JsonNode, objectMapper:ObjectMapper) extends InvocationHandler {
   def invoke(proxy: scala.AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
-    method.getName match{
+    val out = method.getName match{
       //Simple implementation for toString, when the root interface is accessed directly.
-      case "toString" => data.toString //Could also make it pretty?
+      case "toString" => data.toString
       //implement others when it becomes important...ie equals/hash...not sure this matters much for our configs yet?
-      case methodName => data.findValue(PropertyNamingStrategies.KebabCaseStrategy.INSTANCE.translate(methodName)) match {
+
+
+      case methodName => data.findValue(kebab(methodName)) match {
         case null => throw new NotImplementedError(s"Unsupported method name '$methodName', implement it above (probably)!")
-        //Its an object, so instead of using reflection - lets also construct a proxy for this child. This lets us use nested interfaces, neat.
-        case value: ObjectNode => method.getReturnType.getName match {
-          //TODO Option of simple vs Option of complex, later check if target class is interface or not, rather than try.
-          case "scala.Option" => Try(JacksonProxyConfigProvider(value, objectMapper).proxy(Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)).asInstanceOf[AnyRef]) match {
-            case Failure(exception) => Try(objectMapper.readValue(
-              value.toString,
-              Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)
-            ).asInstanceOf[AnyRef]) match {
-              case Failure(exception) => None
-              case Success(value) => Some(value)
-            }
-            case Success(value) => Some(value)
-          }
-          case _ => JacksonProxyConfigProvider(value, objectMapper).proxy(method.getReturnType).asInstanceOf[AnyRef]
+        case value: ObjectNode => handleObject(value,method)
+        case value: ArrayNode => handleArray(value.elements().asScala,innerGenericClass(method))
+        case value => doConvert(value.toString, method.getReturnType)
+      }
+    }
+    //Any -> AnyRef
+    out.asInstanceOf[AnyRef]
+  }
+
+  private def handleObject[T](data: JsonNode, method: Method): Any = {
+    method.getReturnType.getName match {
+      //TODO Option of simple vs Option of complex, later check if target class is interface or not, rather than try.
+      case "scala.Option" => Try(doProxy(data, innerGenericClass(method))) match {
+        case Failure(exception) => Try(doConvert(
+          data.toString,
+          innerGenericClass(method)
+        )) match {
+          case Failure(_) => None
+          case Success(value) => Some(value)
         }
-        case value: ArrayNode => value.elements().asScala.toList.map {
-          //TODO Array item of simple vs Array item of complex, same here, later check if target class is interface or not, rather than try
-          case item: ObjectNode => Try(JacksonProxyConfigProvider(item, objectMapper).proxy(Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)).asInstanceOf[AnyRef]) match {
-            case Failure(_) => objectMapper.readValue(
-              item.toString,
-              Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)
-            ).asInstanceOf[AnyRef]
-            case Success(value) =>  value
-          }
-          case item => objectMapper.readValue(
-            item.toString,
-            Class.forName(method.getGenericReturnType.asInstanceOf[ParameterizedType].getActualTypeArguments.head.getTypeName)
-          ).asInstanceOf[AnyRef]
-        }
-        //Convert the JsonNode object to something typed, like a TextNode to a String...etc
-        case value => objectMapper.readValue(
-          value.toString,
-          method.getReturnType
-        ).asInstanceOf[AnyRef]
+        case Success(value) => Some(value)
+      }
+      case _ => Try(doProxy(data, method.getReturnType)) match {
+        case Failure(_) => doConvert(data.toString, method.getReturnType)
+        case Success(value) => value
       }
     }
   }
+  private def handleArray[T](data:Iterator[JsonNode],target:Class[T]):List[T]={
+    data.toList.map {
+      //TODO Array item of simple vs Array item of complex, same here, later check if target class is interface or not, rather than try
+      case item: ObjectNode => Try(doProxy(item, target)) match {
+        case Failure(_) => doConvert(
+          item.toString,
+          target
+        )
+        case Success(value) => value
+      }
+      case item => doConvert(
+        item.toString,
+        target
+      )
+    }
+  }
+
+  //Convert the JsonNode to something else
+  private def doConvert[T](value:String, returning: Class[T]):T={
+    objectMapper.readValue(value,returning)
+  }
+
+  //Proxy the JsonNode as an interface
+  private def doProxy[T](data: JsonNode, target: Class[T]): T = {
+    JacksonProxyConfigProvider(data, objectMapper).proxy(target)
+  }
+
 }
 
 case class JacksonProxyConfigProvider(private val data: JsonNode, private val objectMapper:ObjectMapper) extends ConfigProvider with ConfigBuilder {

--- a/common-redshift/src/main/scala/com/socrata/config/JacksonYamlConfigSource.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/JacksonYamlConfigSource.scala
@@ -1,0 +1,9 @@
+package com.socrata.config
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import scala.io.Source
+
+case class JacksonYamlConfigSource(resource: String) extends ConfigSource {
+  override def read(): JsonNode = CommonObjectMapperCustomizer.Yaml.readValue(Source.fromResource(resource).mkString, classOf[JsonNode])
+}

--- a/common-redshift/src/main/scala/com/socrata/config/PropertiesFileEnvSource.scala
+++ b/common-redshift/src/main/scala/com/socrata/config/PropertiesFileEnvSource.scala
@@ -1,0 +1,17 @@
+package com.socrata.config
+
+import java.io.FileInputStream
+import java.nio.file.Paths
+import java.util.Properties
+import scala.util.Using
+
+case class PropertiesFileEnvSource(path: String) extends EnvSource {
+  override def read(): Properties = {
+    val properties = new Properties()
+    val target = Paths.get(path).toAbsolutePath.toString
+    Using(new FileInputStream(target)) { fileInputStream =>
+      properties.load(fileInputStream)
+    }
+    properties
+  }
+}

--- a/common-redshift/src/main/scala/com/socrata/converter/FiniteDurationDeserializer.scala
+++ b/common-redshift/src/main/scala/com/socrata/converter/FiniteDurationDeserializer.scala
@@ -1,0 +1,16 @@
+package com.socrata.converter
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+
+import scala.concurrent.duration.{Duration, FiniteDuration}
+
+class FiniteDurationDeserializer extends StdDeserializer[FiniteDuration](classOf[FiniteDuration]){
+  override def deserialize(p: JsonParser, ctxt: DeserializationContext): FiniteDuration = {
+    Duration(p.getText.trim) match {
+      case _: Duration.Infinite => throw ctxt.mappingException("Expected a finite duration, got infinite.")
+      case duration: FiniteDuration => duration
+    }
+  }
+}

--- a/common-redshift/src/test/resources/data/person-dog.yaml
+++ b/common-redshift/src/test/resources/data/person-dog.yaml
@@ -1,0 +1,3 @@
+person:
+  dog:
+    name: Jackson

--- a/common-redshift/src/test/resources/data/person.yaml
+++ b/common-redshift/src/test/resources/data/person.yaml
@@ -1,0 +1,7 @@
+person:
+  name: John
+  age: 20
+  address:
+    country: United States
+    state: New York
+    city: Buffalo

--- a/common-redshift/src/test/resources/data/recipe.yaml
+++ b/common-redshift/src/test/resources/data/recipe.yaml
@@ -1,0 +1,4 @@
+ingredients:
+  - Tomato
+  - Cheese
+  - Bread

--- a/common-redshift/src/test/resources/data/recipe2.yaml
+++ b/common-redshift/src/test/resources/data/recipe2.yaml
@@ -1,0 +1,7 @@
+ingredients:
+  - name: Tomato
+    amount: 3
+  - name: Cheese
+    amount: 32
+  - name: Bread
+    amount: 1

--- a/common-redshift/src/test/resources/data/recipe3.yaml
+++ b/common-redshift/src/test/resources/data/recipe3.yaml
@@ -1,0 +1,13 @@
+ingredients:
+  - name:
+      short: T
+      long: Tomato
+    amount: 3
+  - name:
+      short: C
+      long: Cheese
+    amount: 32
+  - name:
+      short: B
+      long: Bread
+    amount: 1

--- a/common-redshift/src/test/resources/data/resources.yaml
+++ b/common-redshift/src/test/resources/data/resources.yaml
@@ -1,0 +1,3 @@
+cpu: ${CPU_AMOUNT}
+gpu: ${GPU_AMOUNT}
+storage: ${STORAGE_AMOUNT}

--- a/common-redshift/src/test/resources/data/server.yaml
+++ b/common-redshift/src/test/resources/data/server.yaml
@@ -1,0 +1,2 @@
+server:
+  data-dir: ${java.io.tmpdir}

--- a/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
+++ b/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
@@ -1,0 +1,37 @@
+package com.socrata.config
+
+import org.junit.jupiter.api.{DisplayName, Test}
+
+
+@DisplayName("Jackson Proxy Config Tests")
+class JacksonProxyConfigTest {
+
+  @DisplayName("Person sanity test")
+  @Test
+  def person():Unit={
+
+    trait Address {
+      def country(): String
+      def state(): String
+      def city(): String
+    }
+
+    trait Person {
+      def name(): String
+      def age(): Integer
+      def address(): Address
+    }
+
+    val person: Person =
+      JacksonProxyConfigBuilder(CommonObjectMapperCustomizer.Default)
+        .withSources(JacksonYamlConfigSource("data/person.yaml"))
+        .proxy("person", classOf[Person])
+
+    assert("John".equals(person.name()))
+    assert(20.equals(person.age()))
+    assert("United States".equals(person.address().country()))
+    assert("New York".equals(person.address().state()))
+    assert("Buffalo".equals(person.address().city()))
+  }
+
+}

--- a/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
+++ b/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
@@ -68,13 +68,13 @@ class JacksonProxyConfigTest {
         .withSources(JacksonYamlConfigSource("data/recipe2.yaml"))
         .proxy(classOf[Recipe])
 
-    assert(
-      List(
-        Map("name" -> "Tomato", "amount" -> 3),
-        Map("name" -> "Cheese", "amount" -> 32),
-        Map("name" -> "Bread", "amount" -> 1)
-      ).equals(recipe.ingredients())
-    )
+    val ingredients: List[Ingredient] = recipe.ingredients()
+    val tomato: Ingredient = ingredients.filter(_.name().equals("Tomato")).head
+    val cheese: Ingredient = ingredients.filter(_.name().equals("Cheese")).head
+    val bread: Ingredient = ingredients.filter(_.name().equals("Bread")).head
+    assert(3.equals(tomato.amount()))
+    assert(32.equals(cheese.amount()))
+    assert(1.equals(bread.amount()))
   }
 
   @DisplayName("List of super duper complex types")

--- a/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
+++ b/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.{DisplayName, Test}
 @DisplayName("Jackson Proxy Config Tests")
 class JacksonProxyConfigTest {
 
-  @DisplayName("Person sanity test")
+  @DisplayName("Nested traits")
   @Test
   def person():Unit={
 
@@ -32,6 +32,49 @@ class JacksonProxyConfigTest {
     assert("United States".equals(person.address().country()))
     assert("New York".equals(person.address().state()))
     assert("Buffalo".equals(person.address().city()))
+  }
+
+  @DisplayName("List")
+  @Test
+  def list(): Unit = {
+
+    trait Recipe {
+      def ingredients(): List[String]
+    }
+
+    val recipe: Recipe =
+      JacksonProxyConfigBuilder(CommonObjectMapperCustomizer.Default)
+        .withSources(JacksonYamlConfigSource("data/recipe.yaml"))
+        .proxy( classOf[Recipe])
+
+    assert(List("Tomato","Cheese","Bread").equals(recipe.ingredients()))
+  }
+
+  @DisplayName("List of complex type")
+  @Test
+  def listComplex(): Unit = {
+
+    trait Ingredient{
+      def name(): String
+      def amount(): Int
+    }
+
+    trait Recipe {
+      def ingredients(): List[Ingredient]
+    }
+
+    val recipe: Recipe =
+      JacksonProxyConfigBuilder(CommonObjectMapperCustomizer.Default)
+        .withSources(JacksonYamlConfigSource("data/recipe2.yaml"))
+        .proxy(classOf[Recipe])
+
+    assert(
+      List(
+        Map("name" -> "Tomato", "amount" -> 3),
+        Map("name" -> "Cheese", "amount" -> 32),
+        Map("name" -> "Bread", "amount" -> 1)
+      ).equals(recipe.ingredients())
+    )
   }
 
 }

--- a/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
+++ b/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
@@ -111,4 +111,24 @@ class JacksonProxyConfigTest {
     assert("T".equals(tomatoName.short()))
   }
 
+  @DisplayName("Optional")
+  @Test
+  def optional(): Unit = {
+
+    trait Dog {
+      def name(): String
+    }
+
+    trait Person {
+      def dog(): Option[Dog]
+    }
+
+    val person: Person =
+      JacksonProxyConfigBuilder(CommonObjectMapperCustomizer.Default)
+        .withSources(JacksonYamlConfigSource("data/person-dog.yaml"))
+        .proxy("person",classOf[Person])
+
+    assert("Jackson".equals(person.dog().get.name()))
+  }
+
 }

--- a/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
+++ b/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala
@@ -77,4 +77,38 @@ class JacksonProxyConfigTest {
     )
   }
 
+  @DisplayName("List of super duper complex types")
+  @Test
+  def listSuperComplex(): Unit = {
+
+    trait Name{
+      def short(): String
+      def long(): String
+    }
+
+    trait Ingredient {
+      def name(): Name
+
+      def amount(): Int
+    }
+
+    trait Recipe {
+      def ingredients(): List[Ingredient]
+    }
+
+    val recipe: Recipe =
+      JacksonProxyConfigBuilder(CommonObjectMapperCustomizer.Default)
+        .withSources(JacksonYamlConfigSource("data/recipe3.yaml"))
+        .proxy(classOf[Recipe])
+
+    val ingredients:List[Ingredient] = recipe.ingredients()
+    val tomato:Ingredient = ingredients.filter(_.name().long().equals("Tomato")).head
+    val cheese:Ingredient = ingredients.filter(_.name().long().equals("Cheese")).head
+    val Bread:Ingredient = ingredients.filter(_.name().long().equals("Bread")).head
+    assert(3.equals(tomato.amount()))
+    val tomatoName:Name = tomato.name()
+    assert("Tomato".equals(tomatoName.long()))
+    assert("T".equals(tomatoName.short()))
+  }
+
 }

--- a/store-redshift/pom.xml
+++ b/store-redshift/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>soql-redshift-adapter-store</artifactId>
 
     <properties>
-        <secondarylib.version>4.2.17</secondarylib.version>
+        <secondarylib.version>4.2.18</secondarylib.version>
         <guava.version>19.0</guava.version>
         <aws-java-sdk-redshift.version>1.12.565</aws-java-sdk-redshift.version>
     </properties>

--- a/store-redshift/src/main/resources/application.yaml
+++ b/store-redshift/src/main/resources/application.yaml
@@ -14,11 +14,10 @@ redshift:
   message-producer-config:
     eurybates:
       producers: activemq
-      activemq:
-        connection-string: tcp://local.dev.socrata.net:61616
+      activemq-conn-str: tcp://local.dev.socrata.net:61616
     zookeeper:
       conn-spec: local.dev.socrata.net:2181
-      session-timeout: 4s
+      session-timeout: 4
   replay-wait: 2 minutes
   tmpdir: ${java.io.tmpdir}
   watcher-id: ${quarkus.uuid}

--- a/store-redshift/src/main/scala/com/socrata/Application.scala
+++ b/store-redshift/src/main/scala/com/socrata/Application.scala
@@ -1,8 +1,10 @@
+package com.socrata
+
+import com.socrata.config.RedshiftSecondaryConfig
+import com.socrata.config.RedshiftSecondaryDependencies.SecondaryMap
 import com.socrata.datacoordinator.common.DataSourceFromConfig.DSInfo
-import com.socrata.datacoordinator.secondary.{SecondaryWatcherApp, SecondaryWatcherAppConfig}
+import com.socrata.datacoordinator.secondary.SecondaryWatcherApp
 import com.socrata.thirdparty.metrics.MetricsReporter
-import config.RedshiftSecondaryConfig
-import config.RedshiftSecondaryDependencies.SecondaryMap
 import io.quarkus.runtime.QuarkusApplication
 import io.quarkus.runtime.annotations.QuarkusMain
 import org.apache.curator.framework.CuratorFramework

--- a/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryConfig.java
+++ b/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryConfig.java
@@ -1,9 +1,7 @@
-package config;
+package com.socrata.config;
 
 
 import com.socrata.datacoordinator.secondary.SecondaryWatcherAppConfig;
-import io.quarkus.runtime.annotations.StaticInitSafe;
-import io.smallrye.config.ConfigMapping;
 
 public interface RedshiftSecondaryConfig extends SecondaryWatcherAppConfig {
 

--- a/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryDependencies.scala
+++ b/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryDependencies.scala
@@ -46,14 +46,20 @@ class RedshiftSecondaryDependencies {
   def configSource():ConfigSource = JacksonYamlConfigSource("application.yaml")
 
   @Produces
+  def envSource(): EnvSource = PropertiesFileEnvSource(".env")
+
+  @Produces
   def configProvider
   (
     objectMapper:ObjectMapper,
     @All
-    configSources: java.util.List[ConfigSource]
+    configSources: java.util.List[ConfigSource],
+    @All
+    envSources: java.util.List[EnvSource]
   ): ConfigProvider={
     JacksonProxyConfigBuilder(objectMapper)
       .withSources(configSources.asScala.toArray:_*)
+      .withEnvs(envSources.asScala.toArray:_*)
   }
 
   @Produces

--- a/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryDependencies.scala
+++ b/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryDependencies.scala
@@ -2,7 +2,7 @@ package com.socrata.config
 
 import com.codahale.metrics.MetricRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.socrata.config.JacksonConfig
+import com.socrata.config.CommonObjectMapperCustomizer
 import com.socrata.datacoordinator.common.DataSourceFromConfig.DSInfo
 import com.socrata.datacoordinator.secondary.Secondary
 import com.socrata.datacoordinator.secondary.SecondaryWatcherApp.NumWorkers
@@ -37,7 +37,7 @@ object RedshiftSecondaryDependencies {
 class RedshiftSecondaryDependencies {
 
   @Produces
-  def objectMapperCustomizer(): ObjectMapperCustomizer = new JacksonConfig
+  def objectMapperCustomizer(): ObjectMapperCustomizer = new CommonObjectMapperCustomizer
 
   @Produces
   def redshiftSecondaryConfig

--- a/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryDependencies.scala
+++ b/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryDependencies.scala
@@ -1,4 +1,4 @@
-package config
+package com.socrata.config
 
 import com.codahale.metrics.MetricRegistry
 import com.fasterxml.jackson.databind.ObjectMapper
@@ -9,7 +9,7 @@ import com.socrata.datacoordinator.secondary.SecondaryWatcherApp.NumWorkers
 import com.socrata.datacoordinator.secondary.messaging.eurybates.MessageProducerConfig
 import com.socrata.soql.types.{SoQLType, SoQLValue}
 import com.socrata.thirdparty.metrics.{Metrics, MetricsOptions, MetricsReporter}
-import config.RedshiftSecondaryDependencies.{SecondaryBundle, SecondaryMap}
+import com.socrata.config.RedshiftSecondaryDependencies.{SecondaryBundle, SecondaryMap}
 import io.agroal.api.AgroalDataSource
 import io.quarkus.agroal.DataSource
 import io.quarkus.jackson.ObjectMapperCustomizer
@@ -19,7 +19,7 @@ import jakarta.json.JsonObject
 import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
 import org.apache.curator.retry.BoundedExponentialBackoffRetry
 import org.eclipse.microprofile.config.ConfigProvider
-import service.RedshiftSecondary
+import com.socrata.service.RedshiftSecondary
 
 import java.io.{File, OutputStream}
 import java.sql.Connection

--- a/store-redshift/src/main/scala/com/socrata/config/ZookeeperConfig.java
+++ b/store-redshift/src/main/scala/com/socrata/config/ZookeeperConfig.java
@@ -1,4 +1,4 @@
-package config;
+package com.socrata.config;
 
 import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;

--- a/store-redshift/src/main/scala/com/socrata/db/meta/entity/Dataset.scala
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/entity/Dataset.scala
@@ -1,4 +1,4 @@
-package db.meta.entity
+package com.socrata.db.meta.entity
 
 import jakarta.persistence.Entity
 

--- a/store-redshift/src/main/scala/com/socrata/db/meta/entity/DatasetInternalName.scala
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/entity/DatasetInternalName.scala
@@ -1,4 +1,4 @@
-package db.meta.entity
+package com.socrata.db.meta.entity
 
 import io.quarkus.hibernate.orm.panache.PanacheEntity
 import jakarta.persistence.Entity

--- a/store-redshift/src/main/scala/com/socrata/db/meta/package-info.java
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/package-info.java
@@ -1,5 +1,5 @@
-@PersistenceUnit("store")
-package db.store;
+@PersistenceUnit("db/meta")
+package com.socrata.db.meta;
 
 import io.quarkus.hibernate.orm.PersistenceUnit;
 

--- a/store-redshift/src/main/scala/com/socrata/db/meta/repository/DatasetInternalNameRepository.scala
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/repository/DatasetInternalNameRepository.scala
@@ -1,6 +1,6 @@
-package db.meta.repository
+package com.socrata.db.meta.repository
 
-import db.meta.entity.{Dataset, DatasetInternalName}
+import com.socrata.db.meta.entity.{Dataset, DatasetInternalName}
 import io.quarkus.hibernate.orm.panache.PanacheRepository
 import jakarta.enterprise.context.ApplicationScoped
 

--- a/store-redshift/src/main/scala/com/socrata/db/meta/repository/DatasetRepository.scala
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/repository/DatasetRepository.scala
@@ -1,6 +1,6 @@
-package db.meta.repository
+package com.socrata.db.meta.repository
 
-import db.meta.entity.Dataset
+import com.socrata.db.meta.entity.Dataset
 import io.quarkus.hibernate.orm.panache.PanacheRepository
 import jakarta.enterprise.context.ApplicationScoped
 

--- a/store-redshift/src/main/scala/com/socrata/db/meta/service/DatasetInternalNameService.scala
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/service/DatasetInternalNameService.scala
@@ -1,6 +1,6 @@
-package db.meta.service
+package com.socrata.db.meta.service
 
-import db.meta.repository.DatasetInternalNameRepository
+import com.socrata.db.meta.repository.DatasetInternalNameRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.transaction.Transactional
 

--- a/store-redshift/src/main/scala/com/socrata/db/meta/service/DatasetService.scala
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/service/DatasetService.scala
@@ -1,6 +1,6 @@
-package db.meta.service
+package com.socrata.db.meta.service
 
-import db.meta.repository.DatasetRepository
+import com.socrata.db.meta.repository.DatasetRepository
 import jakarta.enterprise.context.ApplicationScoped
 import jakarta.transaction.Transactional
 

--- a/store-redshift/src/main/scala/com/socrata/db/meta/service/MetaService.scala
+++ b/store-redshift/src/main/scala/com/socrata/db/meta/service/MetaService.scala
@@ -1,4 +1,4 @@
-package db.meta.service
+package com.socrata.db.meta.service
 
 import jakarta.enterprise.context.ApplicationScoped
 

--- a/store-redshift/src/main/scala/com/socrata/db/store/package-info.java
+++ b/store-redshift/src/main/scala/com/socrata/db/store/package-info.java
@@ -1,5 +1,5 @@
-@PersistenceUnit("db/meta")
-package db.meta;
+@PersistenceUnit("store")
+package com.socrata.db.store;
 
 import io.quarkus.hibernate.orm.PersistenceUnit;
 

--- a/store-redshift/src/main/scala/com/socrata/service/RedshiftSecondary.scala
+++ b/store-redshift/src/main/scala/com/socrata/service/RedshiftSecondary.scala
@@ -1,13 +1,13 @@
-package service
+package com.socrata.service
 
-import _root_.config.RedshiftSecondaryConfig
+import com.socrata.config.RedshiftSecondaryConfig
 import com.rojoma.simplearm.v2.Managed
 import com.socrata.datacoordinator.secondary.Secondary.Cookie
 import com.socrata.datacoordinator.secondary._
 import com.socrata.datacoordinator.truth.metadata.IndexDirective
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
 import com.socrata.soql.types.{SoQLType, SoQLValue}
-import db.meta.service.MetaService
+import com.socrata.db.meta.service.MetaService
 import io.agroal.api.AgroalDataSource
 import io.quarkus.agroal.DataSource
 import jakarta.enterprise.context.ApplicationScoped

--- a/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
+++ b/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
@@ -1,6 +1,7 @@
 package com.socrata
 
 import com.socrata.config.{ConfigProvider, RedshiftSecondaryConfig}
+import com.socrata.datacoordinator.secondary.messaging.eurybates.{EurybatesConfig, MessageProducerConfig, ZookeeperConfig}
 import io.agroal.api.AgroalDataSource
 import io.quarkus.agroal.DataSource
 import io.quarkus.logging.Log
@@ -21,7 +22,7 @@ class ConfigTest() {
   @DisplayName("one")
   @Test
   def one():Unit = {
-    val redshiftSecondaryConfig = configProvider.proxy("redshift", classOf[RedshiftSecondaryConfig])
+    val redshiftSecondaryConfig: RedshiftSecondaryConfig = configProvider.proxy("redshift", classOf[RedshiftSecondaryConfig])
     assert(Duration("5 minutes").equals(redshiftSecondaryConfig.backoffInterval))
     assert(Duration("30 minutes").equals(redshiftSecondaryConfig.claimTimeout))
     assert("collocation-lock".equals(redshiftSecondaryConfig.collocationLockPath))
@@ -32,13 +33,13 @@ class ConfigTest() {
     assert(redshiftSecondaryConfig.maxReplays.contains(200))
     assert(29.equals(redshiftSecondaryConfig.maxRetries))
 
-    val messageProducerConfig = redshiftSecondaryConfig.messageProducerConfig.get
+    val messageProducerConfig:MessageProducerConfig = redshiftSecondaryConfig.messageProducerConfig.get
 
-    val eurybates = messageProducerConfig.eurybates
+    val eurybates:EurybatesConfig = messageProducerConfig.eurybates
     assert("activemq".equals(eurybates.producers))
     assert("tcp://local.dev.socrata.net:61616".equals(eurybates.activemqConnStr))
 
-    val zookeeper = messageProducerConfig.zookeeper
+    val zookeeper:ZookeeperConfig = messageProducerConfig.zookeeper
     assert("local.dev.socrata.net:2181".equals(zookeeper.connSpec))
     assert(zookeeper.sessionTimeout.equals(4))
 

--- a/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
+++ b/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
@@ -2,26 +2,18 @@ package com.socrata
 
 import com.socrata.config.{ConfigProvider, RedshiftSecondaryConfig}
 import com.socrata.datacoordinator.secondary.messaging.eurybates.{EurybatesConfig, MessageProducerConfig, ZookeeperConfig}
-import io.agroal.api.AgroalDataSource
-import io.quarkus.agroal.DataSource
-import io.quarkus.logging.Log
 import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.{DisplayName, Test}
 
-import java.util.Properties
 import scala.concurrent.duration.Duration
-import scala.util.Using
 
 @DisplayName("Config Tests")
-@QuarkusTest
-class ConfigTest() {
-  @Inject
-  var configProvider: ConfigProvider = _
+@QuarkusTest class ConfigTest() {
+  @Inject var configProvider: ConfigProvider = _
 
   @DisplayName("one")
-  @Test
-  def one():Unit = {
+  @Test def one(): Unit = {
     val redshiftSecondaryConfig: RedshiftSecondaryConfig = configProvider.proxy("redshift", classOf[RedshiftSecondaryConfig])
     assert(Duration("5 minutes").equals(redshiftSecondaryConfig.backoffInterval))
     assert(Duration("30 minutes").equals(redshiftSecondaryConfig.claimTimeout))
@@ -33,18 +25,18 @@ class ConfigTest() {
     assert(redshiftSecondaryConfig.maxReplays.contains(200))
     assert(29.equals(redshiftSecondaryConfig.maxRetries))
 
-    val messageProducerConfig:MessageProducerConfig = redshiftSecondaryConfig.messageProducerConfig.get
+    val messageProducerConfig: MessageProducerConfig = redshiftSecondaryConfig.messageProducerConfig.get
 
-    val eurybates:EurybatesConfig = messageProducerConfig.eurybates
+    val eurybates: EurybatesConfig = messageProducerConfig.eurybates
     assert("activemq".equals(eurybates.producers))
     assert("tcp://local.dev.socrata.net:61616".equals(eurybates.activemqConnStr))
 
-    val zookeeper:ZookeeperConfig = messageProducerConfig.zookeeper
+    val zookeeper: ZookeeperConfig = messageProducerConfig.zookeeper
     assert("local.dev.socrata.net:2181".equals(zookeeper.connSpec))
     assert(zookeeper.sessionTimeout.equals(4))
 
     assert(Duration("2 minutes").equals(redshiftSecondaryConfig.replayWait))
-    assert(redshiftSecondaryConfig.tmpdir!=null)
+    assert(redshiftSecondaryConfig.tmpdir != null)
 
   }
 

--- a/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
+++ b/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
@@ -8,6 +8,8 @@ import io.quarkus.test.junit.QuarkusTest
 import jakarta.inject.Inject
 import org.junit.jupiter.api.{DisplayName, Test}
 
+import java.util.Properties
+import scala.concurrent.duration.Duration
 import scala.util.Using
 
 @DisplayName("Config Tests")
@@ -20,7 +22,29 @@ class ConfigTest() {
   @Test
   def one():Unit = {
     val redshiftSecondaryConfig = configProvider.proxy("redshift", classOf[RedshiftSecondaryConfig])
-    println(redshiftSecondaryConfig.backoffInterval)
+    assert(Duration("5 minutes").equals(redshiftSecondaryConfig.backoffInterval))
+    assert(Duration("30 minutes").equals(redshiftSecondaryConfig.claimTimeout))
+    assert("collocation-lock".equals(redshiftSecondaryConfig.collocationLockPath))
+    assert(Duration("10s").equals(redshiftSecondaryConfig.collocationLockTimeout))
+    assert("${TRUTH_CLUSTER}".equals(redshiftSecondaryConfig.instance))
+    //log4j todo
+    assert(Duration("2 hours").equals(redshiftSecondaryConfig.maxReplayWait))
+    assert(redshiftSecondaryConfig.maxReplays.contains(200))
+    assert(29.equals(redshiftSecondaryConfig.maxRetries))
+
+    val messageProducerConfig = redshiftSecondaryConfig.messageProducerConfig.get
+
+    val eurybates = messageProducerConfig.eurybates
+    assert("activemq".equals(eurybates.producers))
+    assert("tcp://local.dev.socrata.net:61616".equals(eurybates.activemqConnStr))
+
+    val zookeeper = messageProducerConfig.zookeeper
+    assert("local.dev.socrata.net:2181".equals(zookeeper.connSpec))
+    assert(zookeeper.sessionTimeout.equals(4))
+
+    assert(Duration("2 minutes").equals(redshiftSecondaryConfig.replayWait))
+
+
   }
 
 }

--- a/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
+++ b/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
@@ -1,0 +1,26 @@
+package com.socrata
+
+import com.socrata.config.{ConfigProvider, RedshiftSecondaryConfig}
+import io.agroal.api.AgroalDataSource
+import io.quarkus.agroal.DataSource
+import io.quarkus.logging.Log
+import io.quarkus.test.junit.QuarkusTest
+import jakarta.inject.Inject
+import org.junit.jupiter.api.{DisplayName, Test}
+
+import scala.util.Using
+
+@DisplayName("Config Tests")
+@QuarkusTest
+class ConfigTest() {
+  @Inject
+  var configProvider: ConfigProvider = _
+
+  @DisplayName("one")
+  @Test
+  def one():Unit = {
+    val redshiftSecondaryConfig = configProvider.proxy("redshift", classOf[RedshiftSecondaryConfig])
+    println(redshiftSecondaryConfig.backoffInterval)
+  }
+
+}

--- a/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
+++ b/store-redshift/src/test/scala/com/socrata/ConfigTest.scala
@@ -27,7 +27,7 @@ class ConfigTest() {
     assert(Duration("30 minutes").equals(redshiftSecondaryConfig.claimTimeout))
     assert("collocation-lock".equals(redshiftSecondaryConfig.collocationLockPath))
     assert(Duration("10s").equals(redshiftSecondaryConfig.collocationLockTimeout))
-    assert("${TRUTH_CLUSTER}".equals(redshiftSecondaryConfig.instance))
+    assert("alpha".equals(redshiftSecondaryConfig.instance))
     //log4j todo
     assert(Duration("2 hours").equals(redshiftSecondaryConfig.maxReplayWait))
     assert(redshiftSecondaryConfig.maxReplays.contains(200))
@@ -44,7 +44,7 @@ class ConfigTest() {
     assert(zookeeper.sessionTimeout.equals(4))
 
     assert(Duration("2 minutes").equals(redshiftSecondaryConfig.replayWait))
-
+    assert(redshiftSecondaryConfig.tmpdir!=null)
 
   }
 


### PR DESCRIPTION
This lets you use interfaces/traits for configuration with scala support, similar to what quarkus and smallrye do.
You can configure multiple sources for data and environment.
The data will be built up as a merged JsonNode, which can be accessed via a proxy interface.
Think of it as "materializing" a finite view over a JsonNode structure, via JDK proxies and Jackson.
It is assumed properties are mapped via kebab case convention.
Strings containing `${...}` will be expanded with respect to the EnvSources, then System.prop/env.
Reading envs are built in, as its done via System... of course, but the EnvSource lets us use .env files like quarkus does, which is nice for local dev.


There are generic sanity tests found in the [common module](https://github.com/socrata-platform/soql-redshift-adapter/blob/df73a3fa854d650d26d45d1701b4576b32effb68/common-redshift/src/test/scala/com/socrata/config/JacksonProxyConfigTest.scala), please look here to see various examples.

A test showing this working in our actual stuff, [here](https://github.com/socrata-platform/soql-redshift-adapter/blob/df73a3fa854d650d26d45d1701b4576b32effb68/store-redshift/src/test/scala/com/socrata/ConfigTest.scala)


This is how it plugs into quarkus/our secondary, [here](https://github.com/socrata-platform/soql-redshift-adapter/blob/df73a3fa854d650d26d45d1701b4576b32effb68/store-redshift/src/main/scala/com/socrata/config/RedshiftSecondaryDependencies.scala#L45)


In summary:
```scala
@Produces
def configSource():ConfigSource = JacksonYamlConfigSource("application.yaml")


@Produces
def envSource(): EnvSource = PropertiesFileEnvSource(".env")

@Produces
def configProvider
(
  objectMapper:ObjectMapper,
  @All
  configSources: java.util.List[ConfigSource],
  @All
  envSources: java.util.List[EnvSource]
): ConfigProvider={
  JacksonProxyConfigBuilder(objectMapper)
    .withSources(configSources.asScala.toArray:_*)
    .withEnvs(envSources.asScala.toArray:_*)
}

...somewhere later...
  val redshiftSecondaryConfig: RedshiftSecondaryConfig = configProvider.proxy("redshift",classOf[RedshiftSecondaryConfig])
  assert(Duration("5 minutes").equals(redshiftSecondaryConfig.backoffInterval))
  assert(Duration("30 minutes").equals(redshiftSecondaryConfig.claimTimeout))
  assert("collocation-lock".equals(redshiftSecondaryConfig.collocationLockPath))
  assert(Duration("10s").equals(redshiftSecondaryConfig.collocationLockTimeout))
  assert("alpha".equals(redshiftSecondaryConfig.instance))
  //log4j todo
  assert(Duration("2 hours").equals(redshiftSecondaryConfig.maxReplayWait))
  assert(redshiftSecondaryConfig.maxReplays.contains(200))
  assert(29.equals(redshiftSecondaryConfig.maxRetries))

  val messageProducerConfig:MessageProducerConfig = redshiftSecondaryConfig.messageProducerConfig.get

  val eurybates:EurybatesConfig = messageProducerConfig.eurybates
  assert("activemq".equals(eurybates.producers))
  assert("tcp://local.dev.socrata.net:61616".equals(eurybates.activemqConnStr))

  val zookeeper:ZookeeperConfig = messageProducerConfig.zookeeper
  assert("local.dev.socrata.net:2181".equals(zookeeper.connSpec))
  assert(zookeeper.sessionTimeout.equals(4))

  assert(Duration("2 minutes").equals(redshiftSecondaryConfig.replayWait))
  assert(redshiftSecondaryConfig.tmpdir!=null)
```


